### PR TITLE
Asar 0.6.1 update and fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var gutil = require('gulp-util');
 require('terminal-colors');
 
 var Filesystem = require('asar/lib/filesystem');
-var pickle = require('asar/node_modules/chromium-pickle');
+var pickle = require('asar/node_modules/chromium-pickle-js');
 
 const PLUGIN_NAME = 'gulp-asar';
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function(destFilename, opts) {
 			filesystem.insertLink(file.relative, file.stat);
 		}
 		else {
-			filesystem.insertFile(file.relative, file.stat);
+			filesystem.insertFile(file.relative, false, file.stat);
 			outLen += file.contents.length;
 			out.push(file.contents);
 		}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "mocha": "^2.1.0"
   },
   "dependencies": {
-    "asar": "^0.2.2",
+    "asar": "^0.6.1",
     "gulp-util": "^3.0.3",
     "terminal-colors": "^0.1.3",
     "through2": "^1.1.1"


### PR DESCRIPTION
Updated asar dependency (to 0.6.1, latest in npm) and changed reference to chromium-pickle to the newer chromium-pickle-js. This makes installation on Windows much smoother (atom/asar#28) and resolves an outdated dependency.
