### PR TITLE
Use latest asar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: node_js
+node_js:
+- '0.10'
+- '0.12'
+- iojs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-asar",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Gulp plugin to generate atom-shell asar archives.",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "asar": "^0.7.2",
     "gulp-util": "^3.0.3",
     "terminal-colors": "^0.1.3",
-    "through2": "^1.1.1"
+    "through2": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "mocha": "^2.1.0"
   },
   "dependencies": {
-    "asar": "^0.6.1",
+    "asar": "^0.7.2",
     "gulp-util": "^3.0.3",
     "terminal-colors": "^0.1.3",
     "through2": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/bwin/gulp-asar",
   "devDependencies": {
     "gulp": "^3.8.11",
-    "mocha": "^2.1.0"
+    "mocha": "^2.2.5"
   },
   "dependencies": {
     "asar": "^0.7.2",

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,8 @@
+var assert = require("assert")
+describe('gulp-asar', function() {
+  describe('noop()', function () {
+    it('test placeholder', function () {
+      assert.equal(true, true);
+    });
+  });
+});


### PR DESCRIPTION
The latest build of asar plays a lot nicer on Windows because it uses chromium-pickle-js rather than some natively compiled cpp code.

Any chance of a quick update? Thanks!
