### PR TITLE
Proposed new release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: node_js
+node_js:
+- '0.10'
+- '0.12'
+- iojs

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
-
 var through = require('through2');
 var gutil = require('gulp-util');
-require('terminal-colors');
 
 var Filesystem = require('asar/lib/filesystem');
 var pickle = require('asar/node_modules/chromium-pickle-js');
@@ -11,7 +9,7 @@ const PLUGIN_NAME = 'gulp-asar';
 module.exports = function(destFilename, opts) {
 	opts = opts || {};
 	if (!destFilename) {
-		throw new gutil.PluginError(PLUGIN_NAME, 'destFilename'.blue + ' required');
+		throw new gutil.PluginError(PLUGIN_NAME, 'destFilename required');
 	}
 
 	var cwd = opts.base || process.cwd(); // ?

--- a/index.js
+++ b/index.js
@@ -24,15 +24,18 @@ module.exports = function(destFilename, opts) {
 
     if (file.stat.isDirectory()) {
       filesystem.insertDirectory(file.relative);
+      cb();
     } else if (file.stat.isSymbolicLink()) {
       filesystem.insertLink(file.relative, file.stat);
+      cb();
     } else {
-      filesystem.insertFile(file.relative, false, file.stat);
-      outLen += file.contents.length;
-      out.push(file.contents);
-    }
+      filesystem.insertFile(file.relative, false, file, {}, function() {
+        outLen += file.contents.length;
+        out.push(file.contents);
 
-    cb();
+        cb();
+      });
+    }
   }, function(cb) {
     var headerPickle = pickle.createEmpty();
     headerPickle.writeString(JSON.stringify(filesystem.header));

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var through = require('through2');
 var gutil = require('gulp-util');
 
 var Filesystem = require('asar/lib/filesystem');
-var pickle = require('asar/node_modules/chromium-pickle-js');
+var pickle = require('chromium-pickle-js');
 
 const PLUGIN_NAME = 'gulp-asar';
 

--- a/index.js
+++ b/index.js
@@ -29,6 +29,9 @@ module.exports = function(destFilename, opts) {
       filesystem.insertLink(file.relative, file.stat);
       cb();
     } else {
+      // File length could have changed if the file have been modified:
+      file.stat.size = file.contents.length;
+
       filesystem.insertFile(file.relative, false, file, {}, function() {
         outLen += file.contents.length;
         out.push(file.contents);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-asar",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Gulp plugin to generate atom-shell asar archives.",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "asar": "^0.7.2",
     "gulp-util": "^3.0.3",
-    "terminal-colors": "^0.1.3",
     "through2": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-asar",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Gulp plugin to generate Electron .asar archives.",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "asar": "^0.7.2",
     "gulp-util": "^3.0.3",
     "terminal-colors": "^0.1.3",
-    "through2": "^1.1.1"
+    "through2": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-asar",
   "version": "0.0.3",
-  "description": "Gulp plugin to generate atom-shell asar archives.",
+  "description": "Gulp plugin to generate Electron .asar archives.",
   "main": "index.js",
   "engines": {
     "node": ">= 0.10.0"
@@ -16,7 +16,7 @@
   "keywords": [
     "gulpplugin",
     "asar",
-    "atom-shell"
+    "electron"
   ],
   "author": "Benjamin Winkler (bwin)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
     "mocha": "^2.2.5"
   },
   "dependencies": {
-    "asar": "^0.7.2",
+    "asar": "^0.13.0",
     "gulp-util": "^3.0.3",
+    "chromium-pickle-js": "^0.2.0",
     "through2": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "mocha": "^2.1.0"
   },
   "dependencies": {
-    "asar": "^0.6.1",
+    "asar": "^0.7.2",
     "gulp-util": "^3.0.3",
     "terminal-colors": "^0.1.3",
     "through2": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/bwin/gulp-asar",
   "devDependencies": {
     "gulp": "^3.8.11",
-    "mocha": "^2.1.0"
+    "mocha": "^2.2.5"
   },
   "dependencies": {
     "asar": "^0.7.2",

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,8 @@
+var assert = require("assert")
+describe('gulp-asar', function() {
+  describe('noop()', function () {
+    it('test placeholder', function () {
+      assert.equal(true, true);
+    });
+  });
+});


### PR DESCRIPTION
This PR further updates the work started by @Gaff, with `asar` now updated to `^0.13.0` and a small change to make it work with modern npm's `node_modules` layout (see https://github.com/bwin/gulp-asar/commit/397106e4adc836085060342c1394d5cbb14e6a7f).

As a side note and a reminder, npm Support will be grantimg me access to `gulp-asar` package on npmjs.com on **February, 7th** — please respond in the relevant email thread (should be in your inbox; or just let me know) if you mind that.